### PR TITLE
Add File and Media migration examples

### DIFF
--- a/d8_site/web/modules/database_migration_examples/d7_file_migration_example/d7_file_migration_example.info.yml
+++ b/d8_site/web/modules/database_migration_examples/d7_file_migration_example/d7_file_migration_example.info.yml
@@ -1,0 +1,9 @@
+name: D7 File Migration Example
+type: module
+description: Demonstrates how a file can be migrated.
+core: 8.x
+package: Migration Example modules
+dependencies:
+  - migrate
+  - migrate_plus
+  - migrate_tools

--- a/d8_site/web/modules/database_migration_examples/d7_file_migration_example/d7_file_migration_example.module
+++ b/d8_site/web/modules/database_migration_examples/d7_file_migration_example/d7_file_migration_example.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains d7_file_migration_example.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function d7_file_migration_example_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the d7_file_migration_example module.
+    case 'help.page.d7_file_migration_example':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Demonstrates how a file can be migrated.') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/d8_site/web/modules/database_migration_examples/d7_file_migration_example/migrations/migrate_plus.migration.d7_file_migration_example.yml
+++ b/d8_site/web/modules/database_migration_examples/d7_file_migration_example/migrations/migrate_plus.migration.d7_file_migration_example.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+# This migration is not dependent on other modules.
+dependencies: {  }
+# Machine name of the migration.
+id: d7_file_migration_example
+# Use the default plugin class.
+class: Drupal\migrate\Plugin\Migration
+# Use the default field plugin method.
+field_plugin_method: {  }
+# Use the default cck plugin method.
+cck_plugin_method: {  }
+# Migration tags to which this migration belongs.
+migration_tags:
+  - 'Drupal 7'
+# Migration group to which this migration belongs.
+migration_group: d7_migration_group_example
+# Human friendly name of the migration for various UI and CLI tools.
+label: 'Example Files Migration'
+source:
+  # Drupal's core taxonomy term plugin.
+  plugin: d7_file
+  constants:
+    file_origin: 'http://d7site.drupal-migration.lndo.site/sites/default/files/'
+process:
+  d7_path:
+    plugin: concat
+    source:
+      - constants/file_origin
+      - filename
+  filename: filename
+  uri: uri
+  filemime: filemime
+  filesize: filesize
+  status: status
+  type: type
+  uid: uid
+  # Since we have separate file systems, this downloads the file using the constant above.
+  download_file:
+    plugin: download
+    source:
+      - '@d7_path'
+      - uri
+    file_exists: rename
+destination:
+  plugin: 'entity:file'
+# This migration dependent on the another migration.
+migration_dependencies:
+  required: {}
+  optional: {}

--- a/d8_site/web/modules/database_migration_examples/d7_media_migration_example/d7_media_migration_example.info.yml
+++ b/d8_site/web/modules/database_migration_examples/d7_media_migration_example/d7_media_migration_example.info.yml
@@ -1,0 +1,12 @@
+name: D7 File to Media Migration Example
+type: module
+description: Demonstrates how a file can be migrated into a Media entity.
+core: 8.x
+package: Migration Example modules
+dependencies:
+  - migrate
+  - migrate_plus
+  - migrate_tools
+  - media
+  - d7_migration_group_example
+  - d7_file_migration_example

--- a/d8_site/web/modules/database_migration_examples/d7_media_migration_example/d7_media_migration_example.module
+++ b/d8_site/web/modules/database_migration_examples/d7_media_migration_example/d7_media_migration_example.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains d7_media_migration_example.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function d7_media_migration_example_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the d7_media_migration_example module.
+    case 'help.page.d7_media_migration_example':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Demonstrates how a File from Drupal 7 can be migrated to Media in Drupal 8.') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/d8_site/web/modules/database_migration_examples/d7_media_migration_example/migrations/migrate_plus.migration.audio_media_migration_example.yml
+++ b/d8_site/web/modules/database_migration_examples/d7_media_migration_example/migrations/migrate_plus.migration.audio_media_migration_example.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+# This migration depends on the File Migration Example.
+dependencies:
+  enforced:
+    module:
+      - d7_file_migration_example
+      - d7_migration_group_example
+      - d7_media_migration_example
+# Machine name of the migration.
+id: audio_media_migration_example
+# Use the default plugin class.
+class: Drupal\migrate\Plugin\Migration
+# Use the default field plugin method.
+field_plugin_method: {  }
+# Use the default cck plugin method.
+cck_plugin_method: {  }
+# Migration tags to which this migration belongs.
+migration_tags:
+  - 'Drupal 7'
+# Migration group to which this migration belongs.
+migration_group: d7_migration_group_example
+# Human friendly name of the migration for various UI and CLI tools.
+label: 'Example Media Migration'
+source:
+  # The custom source plugin @ d7_media_migration_example/src/Plugin/migrate/source/FileToMediaExample.php.
+  plugin: file_to_media_example
+  # The type of Media entity being migrated.
+  type: audio
+process:
+  bundle: type
+  name: filename
+  thumbnail_title: filename
+  field_media_audio_file/target_id:
+    plugin: migration_lookup
+    migration: d7_file_migration_example
+    source: fid
+  field_media_audio_file/display:
+    plugin: default_value
+    default_value: 1
+  field_credit: field_soundtrack_credits
+destination:
+  plugin: 'entity:media'
+# This migration is dependent on the File migration.
+migration_dependencies:
+  required: 
+    - d7_file_migration_example
+  optional: {}

--- a/d8_site/web/modules/database_migration_examples/d7_media_migration_example/migrations/migrate_plus.migration.image_media_migration_example.yml
+++ b/d8_site/web/modules/database_migration_examples/d7_media_migration_example/migrations/migrate_plus.migration.image_media_migration_example.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+# This migration depends on the File Migration Example.
+dependencies:
+  enforced:
+    module:
+      - d7_file_migration_example
+      - d7_migration_group_example
+      - d7_media_migration_example
+# Machine name of the migration.
+id: image_media_migration_example
+# Use the default plugin class.
+class: Drupal\migrate\Plugin\Migration
+# Use the default field plugin method.
+field_plugin_method: {  }
+# Use the default cck plugin method.
+cck_plugin_method: {  }
+# Migration tags to which this migration belongs.
+migration_tags:
+  - 'Drupal 7'
+# Migration group to which this migration belongs.
+migration_group: d7_migration_group_example
+# Human friendly name of the migration for various UI and CLI tools.
+label: 'Example Media Migration'
+source:
+  # Custom plugin from this module.
+  plugin: file_to_media_example
+  # Used in source plugin to get correct node data.
+  type: image
+process:
+  bundle: type
+  name: name
+  # Adds data to each column in the field_media_image
+  field_media_image:
+  # Using field_image from D7, migrate data for each of the below based off the current key.
+      plugin: sub_process
+      source: field_image
+      process:
+        target_id:
+            plugin: migration_lookup
+            migration: d7_file_migration_example
+            source: fid
+        title: title
+        alt: alt
+        width: width
+        height: height
+  # Use value from D7 Node for field_image_caption found in source plugin.
+  field_caption: field_image_caption
+destination:
+  plugin: 'entity:media'
+# This migration is dependent on the File migration.
+migration_dependencies:
+  required: 
+    - d7_file_migration_example
+  optional: {}

--- a/d8_site/web/modules/database_migration_examples/d7_media_migration_example/src/Plugin/migrate/source/FileToMediaExample.php
+++ b/d8_site/web/modules/database_migration_examples/d7_media_migration_example/src/Plugin/migrate/source/FileToMediaExample.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Drupal\d7_media_migration_example\Plugin\migrate\source;
+
+use Drupal\migrate\Row;
+use Drupal\migrate_drupal\Plugin\migrate\source\d7\FieldableEntity;
+
+/**
+ * Use D7 database files managed table to create Media entities based on type.
+ *
+ * Extends FieldableEntity to gain access to the getFields method.
+ *
+ * The id to use in the migration yml source plugin definition.
+ *
+ * @MigrateSource(
+ *   id = "file_to_media_example",
+ *   source_module = "file",
+ * )
+ */
+class FileToMediaExample extends FieldableEntity {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Source Data is queried from the 'files_managed' table.
+    $query = $this->select('file_managed', 'fm')
+      ->fields('fm');
+    // Only get a specific type of file specified in the migration yml source.
+    if (isset($this->configuration['type'])) {
+      $query->condition('fm.type', $this->configuration['type']);
+    }
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'fid' => $this->t('File Id'),
+      'filename' => $this->t('File Name'),
+      'uri' => $this->t('File URI'),
+      'filemime' => $this->t('File Mimetype'),
+      'filesize' => $this->t('File Size'),
+      'status' => $this->t('File Status'),
+      'timestamp' => $this->t('File Timestamp'),
+      'type' => $this->t('File Type'),
+      'uid' => $this->t('File uploaded by'),
+    ];
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Assigns the unique key for each migration.
+   */
+  public function getIds() {
+    return [
+      'fid' => [
+        'type' => 'integer',
+        'alias' => 'f',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The prepareRow method helps get additional data that wasn't included in the
+   * initial query, like field data on a node.
+   *
+   * Find a node in the D7 database by matching the current fid being migrated,
+   * and use found node gives access to any field data for the particular nid.
+   * To new field, add the field to the yml file, i.e. field_credit.
+   */
+  public function prepareRow(Row $row) {
+    if (parent::prepareRow($row)) {
+      $file_id = $row->getSourceProperty('fid');
+      if (isset($this->configuration['type']) && $this->configuration['type'] === 'audio') {
+        $query = $this->select('field_data_field_soundtrack', 'fs');
+        $query->join('node', 'n', 'n.nid = fs.entity_id');
+        $query->condition('fs.field_soundtrack_fid', $file_id);
+
+        $node_fields = $query->fields('n')
+          ->execute()
+          ->fetchAll();
+
+        if (isset($node_fields[0])) {
+          foreach (array_keys($this->getFields('node', 'lizard')) as $field) {
+            $row->setSourceProperty($field, $this->getFieldValues('node', $field, $node_fields[0]['nid']));
+          }
+        }
+      }
+      elseif (isset($this->configuration['type']) && $this->configuration['type'] === 'image') {
+        $query = $this->select('field_data_field_image', 'fc');
+        $query->join('node', 'n', 'n.nid = fc.entity_id');
+        $query->condition('fc.field_image_fid', $file_id);
+
+        $node_fields = $query->fields('n')
+          ->execute()
+          ->fetchAll();
+
+        if (isset($node_fields[0])) {
+          foreach (array_keys($this->getFields('node', 'lizard')) as $field) {
+            $row->setSourceProperty($field, $this->getFieldValues('node', $field, $node_fields[0]['nid']));
+          }
+        }
+      }
+
+    }
+    return parent::prepareRow($row);
+  }
+
+}


### PR DESCRIPTION
This PR adds the File migration example and two Media migrations. I didn't update the README as I wanted to find out if there was going to be a more robust way to step through each migration or if each migration should come with it's own README to keep everything shorter as the module grows. 